### PR TITLE
Skal opprette flettefelt

### DIFF
--- a/schemas/felles/customBlock.tsx
+++ b/schemas/felles/customBlock.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 
-import { CustomSanityTyper, SanityTyper } from '../typer'
+import { CustomSanityTyper, SanityTyper, EFlettefelt } from '../typer'
+import { rgba } from 'polished'
+import { Rule } from '@sanity/types'
 
 const customBlock = {
   title: 'Custom block',
@@ -26,6 +28,37 @@ const customBlock = {
                 name: 'blank',
                 type: 'boolean',
                 initialValue: true,
+              },
+            ],
+          },
+          {
+            name: 'flettefelt',
+            type: SanityTyper.OBJECT,
+            title: 'Flettefelt',
+            icon: () => <span>F</span>,
+            render: (props: any) => (
+              <span
+                style={{
+                  backgroundColor: rgba(30, 133, 209, 0.2),
+                  color: 'black',
+                  cursor: 'pointer',
+                }}
+              >
+                {props.flettefeltVerdi ? props.flettefeltVerdi : 'VELG FLETTEFELT'}
+              </span>
+            ),
+            fields: [
+              {
+                name: 'flettefeltVerdi',
+                type: SanityTyper.STRING,
+                title: 'Flettefeltverdier',
+                validation: (rule: Rule) => rule.required().error('Du må velge gyldig flettefelt!'),
+                options: {
+                  list: [
+                    { title: 'Søkers navn', value: EFlettefelt.SØKER_NAVN },
+                    { title: 'Barnets Navn', value: EFlettefelt.BARN_NAVN },
+                  ],
+                },
               },
             ],
           },

--- a/schemas/felles/customBlock.tsx
+++ b/schemas/felles/customBlock.tsx
@@ -52,7 +52,8 @@ const customBlock = {
                 name: 'flettefeltVerdi',
                 type: SanityTyper.STRING,
                 title: 'Flettefeltverdier',
-                validation: (rule: Rule) => rule.required().error('Du må velge gyldig flettefelt!'),
+                validation: (rule: Rule) =>
+                  rule.required().error('Du må velge et gyldig flettefelt!'),
                 options: {
                   list: [{ title: 'Søkers navn', value: EFlettefelt.SØKER_NAVN }],
                 },

--- a/schemas/felles/customBlock.tsx
+++ b/schemas/felles/customBlock.tsx
@@ -54,10 +54,7 @@ const customBlock = {
                 title: 'Flettefeltverdier',
                 validation: (rule: Rule) => rule.required().error('Du må velge gyldig flettefelt!'),
                 options: {
-                  list: [
-                    { title: 'Søkers navn', value: EFlettefelt.SØKER_NAVN },
-                    { title: 'Barnets Navn', value: EFlettefelt.BARN_NAVN },
-                  ],
+                  list: [{ title: 'Søkers navn', value: EFlettefelt.SØKER_NAVN }],
                 },
               },
             ],

--- a/schemas/typer.ts
+++ b/schemas/typer.ts
@@ -73,3 +73,8 @@ export enum Steg {
 export const stegTittel: Record<Steg, string> = {
   FORSIDE: 'Forside',
 }
+
+export enum EFlettefelt {
+  SØKER_NAVN = 'SØKER_NAVN',
+  BARN_NAVN = 'BARN_NAVN',
+}

--- a/schemas/typer.ts
+++ b/schemas/typer.ts
@@ -76,5 +76,4 @@ export const stegTittel: Record<Steg, string> = {
 
 export enum EFlettefelt {
   SØKER_NAVN = 'SØKER_NAVN',
-  BARN_NAVN = 'BARN_NAVN',
 }


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
Må legge opp til bruk av flettefelt i Sanity, slik at det kan videreutvikles til å legge inn søkers navn i veilederen m.m.
[Lenke til trello kort](https://trello.com/c/GAETm1rG/51-legge-opp-til-flettefelt-i-sanity)

### Hvordan er det løst? 🧠
Mye inspirasjon er hentet fra [BAKS Søknad Sanity](https://github.com/navikt/familie-baks-soknad-sanity/blob/master/schemas/felles/customBlock.tsx#LL34C12-L34C12). Har lagt inn customBlock med SØKER_NAVN, slik at dette kan velges som flettefelt i Sanity.

Bilde under viser i Sanity studio en knapp _F_ som gjer det mulig at man kan velge flette tekster.
Skjermbilde viser også at man kan velge hvilken type flette tekst dette skal være. 

<img width="751" alt="Screenshot 2023-06-19 at 14 47 35" src="https://github.com/bekk/nav-familie-endringsmelding-sanity/assets/66110094/f0f2e57d-d7c2-4e00-8061-ab4cb5c10b3b">
