### PR TITLE
Fix vising av mapper

### DIFF
--- a/schemas/typer.ts
+++ b/schemas/typer.ts
@@ -73,7 +73,7 @@ export enum Steg {
 
 export const stegTittel: Record<Steg, string> = {
   FORSIDE: 'Forside',
-  SEND_ENDRINGER: 'Send Endringer',
+  SEND_ENDRINGER: 'Send endringer',
 }
 
 export enum EFlettefelt {

--- a/schemas/typer.ts
+++ b/schemas/typer.ts
@@ -68,10 +68,12 @@ export const ytelseTittel: Record<Ytelse, string> = {
 
 export enum Steg {
   FORSIDE = 'FORSIDE',
+  SEND_ENDRINGER = 'SEND_ENDRINGER',
 }
 
 export const stegTittel: Record<Steg, string> = {
   FORSIDE: 'Forside',
+  SEND_ENDRINGER: 'Send Endringer',
 }
 
 export enum EFlettefelt {

--- a/schemas/ytelse/barnetrygd.ts
+++ b/schemas/ytelse/barnetrygd.ts
@@ -3,5 +3,5 @@ import { Steg, Ytelse } from '../typer'
 
 export const barnetrygd = () => {
   const barnetrygdLocaleDokument = localeDokument(Ytelse.BARNETRYGD)
-  return [barnetrygdLocaleDokument(Steg.FORSIDE)]
+  return [barnetrygdLocaleDokument(Steg.FORSIDE), barnetrygdLocaleDokument(Steg.SEND_ENDRINGER)]
 }

--- a/structure.ts
+++ b/structure.ts
@@ -13,7 +13,12 @@ export const structure = (S: StructureBuilder, _context: StructureContext) => {
 
   return S.list()
     .title('Endringsdialog')
-    .items([lagYtelsemappe(Ytelse.BARNETRYGD, [lagStegmappe(Ytelse.BARNETRYGD, Steg.FORSIDE)])])
+    .items([
+      lagYtelsemappe(Ytelse.BARNETRYGD, [
+        lagStegmappe(Ytelse.BARNETRYGD, Steg.FORSIDE),
+        lagStegmappe(Ytelse.BARNETRYGD, Steg.SEND_ENDRINGER),
+      ]),
+    ])
 }
 
 const lagStegmappeFunksjon =


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

Skal fikse problemet med at mappen til steg 1 ikke vises.
Trudde det var noe som ble fikset i prod, men misforstod litt, og alt var ok når vi testet det lokalt og vi såg dette: 
<img width="376" alt="Screenshot 2023-06-22 at 14 34 47" src="https://github.com/bekk/nav-familie-endringsmelding-sanity/assets/66110094/7325d504-a361-46aa-9a2f-1606ff2191c3">

Litt bedre testing på meg og Sedric neste gang ☀️

### Hvordan er det løst? 🧠

Følgende kodesnutt i `structure.ts` løste problemet:

```typescript
export const structure = (S: StructureBuilder, _context: StructureContext) => {
  const lagYtelsemappe = lagYtelseMappeFunksjon(S)
  const lagStegmappe = lagStegmappeFunksjon(S)

  return S.list()
    .title('Endringsdialog')
    .items([
      lagYtelsemappe(Ytelse.BARNETRYGD, [
        lagStegmappe(Ytelse.BARNETRYGD, Steg.FORSIDE),
        lagStegmappe(Ytelse.BARNETRYGD, Steg.SEND_ENDRINGER),
      ]),
    ])
}


```