### PR TITLE
Felles mappe

### DIFF
--- a/schemas/typer.ts
+++ b/schemas/typer.ts
@@ -69,11 +69,13 @@ export const ytelseTittel: Record<Ytelse, string> = {
 export enum Steg {
   FORSIDE = 'FORSIDE',
   SEND_ENDRINGER = 'SEND_ENDRINGER',
+  FELLES = 'FELLES',
 }
 
 export const stegTittel: Record<Steg, string> = {
   FORSIDE: 'Forside',
   SEND_ENDRINGER: 'Send endringer',
+  FELLES: 'Felles',
 }
 
 export enum EFlettefelt {

--- a/schemas/ytelse/barnetrygd.ts
+++ b/schemas/ytelse/barnetrygd.ts
@@ -3,5 +3,9 @@ import { Steg, Ytelse } from '../typer'
 
 export const barnetrygd = () => {
   const barnetrygdLocaleDokument = localeDokument(Ytelse.BARNETRYGD)
-  return [barnetrygdLocaleDokument(Steg.FORSIDE), barnetrygdLocaleDokument(Steg.SEND_ENDRINGER)]
+  return [
+    barnetrygdLocaleDokument(Steg.FORSIDE),
+    barnetrygdLocaleDokument(Steg.SEND_ENDRINGER),
+    barnetrygdLocaleDokument(Steg.FELLES),
+  ]
 }

--- a/structure.ts
+++ b/structure.ts
@@ -17,6 +17,7 @@ export const structure = (S: StructureBuilder, _context: StructureContext) => {
       lagYtelsemappe(Ytelse.BARNETRYGD, [
         lagStegmappe(Ytelse.BARNETRYGD, Steg.FORSIDE),
         lagStegmappe(Ytelse.BARNETRYGD, Steg.SEND_ENDRINGER),
+        lagStegmappe(Ytelse.BARNETRYGD, Steg.FELLES),
       ]),
     ])
 }


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

Alle steg som inneholder fleire tekster kan hente tekster fra felles mappen.

- Da ungår du å lage fleire tekster for samme tekst verdi
- Kun et API navn for den samme teksten
- Lett å bytte tekst på felles komponenter 


### Hvordan er det løst? 🧠

På samme måte som da vi la inn `send endringer` mappen, så kan vi legge inn felles mappen.
Fungerer ganske bra. Denne gangen husket eg også å passe på at mappen blir vist riktig i Sanity ☀️

<img width="660" alt="Screenshot 2023-06-28 at 10 45 39" src="https://github.com/bekk/nav-familie-endringsmelding-sanity/assets/66110094/59998eee-dbca-4164-a3ed-b57ed9d17f97">
