### PR TITLE
legg til innsendt tid som flettefeltverdi

### DIFF
--- a/schemas/felles/customBlock.tsx
+++ b/schemas/felles/customBlock.tsx
@@ -55,7 +55,10 @@ const customBlock = {
                 validation: (rule: Rule) =>
                   rule.required().error('Du må velge et gyldig flettefelt!'),
                 options: {
-                  list: [{ title: 'Søkers navn', value: EFlettefelt.SØKER_NAVN }],
+                  list: [
+                    { title: 'Søkers navn', value: EFlettefelt.SØKER_NAVN },
+                    { title: 'Innsendt tid', value: EFlettefelt.INNSENDT_TID },
+                  ],
                 },
               },
             ],

--- a/schemas/typer.ts
+++ b/schemas/typer.ts
@@ -82,4 +82,5 @@ export const stegTittel: Record<Steg, string> = {
 
 export enum EFlettefelt {
   SØKER_NAVN = 'SØKER_NAVN',
+  INNSENDT_TID = 'INNSENDT_TID',
 }


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

Må legge inn flettefelt for å få inn riktig innsendt tid til bekreftelsesboks på kvitterringssiden
[Lenke til trello kort](https://trello.com/c/LKsGcPJn/108-fikse-logikk-i-stegindikator)

### Hvordan er det løst? 🧠
Lagt inn flettefeltverdi `INNSENDT_TID` ved alle flettefelt-områder i repo