### PR TITLE
Lag ny mappe for kontantstøtte

### DIFF
--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -1,4 +1,5 @@
 import customBlock from './felles/customBlock'
 import { barnetrygd } from './ytelse/barnetrygd'
+import { kontantstøtte } from './ytelse/kontantstøtte'
 
-export const schemaTypes = [customBlock, ...barnetrygd()]
+export const schemaTypes = [customBlock, ...barnetrygd(), ...kontantstøtte()]

--- a/schemas/typer.ts
+++ b/schemas/typer.ts
@@ -60,10 +60,12 @@ export enum CustomSanityTyper {
 
 export enum Ytelse {
   BARNETRYGD = 'BARNETRYGD',
+  KONTANTSTOTTE = 'KONTANTSTOTTE',
 }
 
 export const ytelseTittel: Record<Ytelse, string> = {
   BARNETRYGD: 'Barnetrygd',
+  KONTANTSTOTTE: 'Kontantstøtte',
 }
 
 export enum Steg {

--- a/schemas/ytelse/kontantstøtte.ts
+++ b/schemas/ytelse/kontantstøtte.ts
@@ -1,0 +1,12 @@
+import localeDokument from '../felles/localeDokument'
+import { Steg, Ytelse } from '../typer'
+
+export const kontantstøtte = () => {
+  const kontantstøtteLocaleDokument = localeDokument(Ytelse.KONTANTSTOTTE)
+  return [
+    kontantstøtteLocaleDokument(Steg.FORSIDE),
+    kontantstøtteLocaleDokument(Steg.SEND_ENDRINGER),
+    kontantstøtteLocaleDokument(Steg.KVITTERING),
+    kontantstøtteLocaleDokument(Steg.FELLES),
+  ]
+}

--- a/structure.ts
+++ b/structure.ts
@@ -20,6 +20,12 @@ export const structure = (S: StructureBuilder, _context: StructureContext) => {
         lagStegmappe(Ytelse.BARNETRYGD, Steg.KVITTERING),
         lagStegmappe(Ytelse.BARNETRYGD, Steg.FELLES),
       ]),
+      lagYtelsemappe(Ytelse.KONTANTSTOTTE, [
+        lagStegmappe(Ytelse.KONTANTSTOTTE, Steg.FORSIDE),
+        lagStegmappe(Ytelse.KONTANTSTOTTE, Steg.SEND_ENDRINGER),
+        lagStegmappe(Ytelse.KONTANTSTOTTE, Steg.KVITTERING),
+        lagStegmappe(Ytelse.KONTANTSTOTTE, Steg.FELLES),
+      ]),
     ])
 }
 


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
For at stønadene skal kunne vise forskjellig tekst i komponentene må det legges inn tekst for kontantstøtte i Sanity. Derfor 
er det laget en egen mappe for kontantstøtte med de samme mappene og feltene som barnetrygd, men med noe ulik tekst. 

[Lenke til trello kort](https://trello.com/c/2r1gWHqd/131-oppdatere-sanity-oppsett)

### Hvordan er det løst? 🧠
Først er det laget en ny mappe for kontantstøtte ved å lage en egen fil `kontantstøtte.ts` som spesifiserer de ulike mappene for stegene til endringsmeldingen. I tillegg er kontantstøtte lagt til i enumen for ytelser og i `structure.ts` for å faktisk lage mappen i Sanity. 