### PR TITLE
Endret fra innsendt_tid til mottattdato

### DIFF
--- a/schemas/felles/customBlock.tsx
+++ b/schemas/felles/customBlock.tsx
@@ -58,7 +58,7 @@ const customBlock = {
                 options: {
                   list: [
                     { title: 'Søkers navn', value: EFlettefelt.SØKER_NAVN },
-                    { title: 'mottatt dato', value: EFlettefelt.MOTTATT_DATO },
+                    { title: 'Mottatt dato', value: EFlettefelt.MOTTATT_DATO },
                   ],
                 },
               },

--- a/schemas/felles/customBlock.tsx
+++ b/schemas/felles/customBlock.tsx
@@ -58,7 +58,7 @@ const customBlock = {
                 options: {
                   list: [
                     { title: 'Søkers navn', value: EFlettefelt.SØKER_NAVN },
-                    { title: 'Innsendt tid', value: EFlettefelt.INNSENDT_TID },
+                    { title: 'mottatt dato', value: EFlettefelt.MOTTATT_DATO },
                   ],
                 },
               },

--- a/schemas/typer.ts
+++ b/schemas/typer.ts
@@ -84,5 +84,5 @@ export const stegTittel: Record<Steg, string> = {
 
 export enum EFlettefelt {
   SØKER_NAVN = 'SØKER_NAVN',
-  MOTTATT_DATO = 'MOTATT_DATO',
+  MOTTATT_DATO = 'MOTTATT_DATO',
 }

--- a/schemas/typer.ts
+++ b/schemas/typer.ts
@@ -84,5 +84,5 @@ export const stegTittel: Record<Steg, string> = {
 
 export enum EFlettefelt {
   SØKER_NAVN = 'SØKER_NAVN',
-  INNSENDT_TID = 'INNSENDT_TID',
+  MOTTATT_DATO = 'MOTATT_DATO',
 }


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

I api-et så heter det mottatt dato mens i sanity heter den innsendt tid i kodebasen varierer det derfor hva det heter om det er i api-et eller sanity
[Lenke til trello kort](https://trello.com/c/RndHBVlV/116-navnebestemmelse-for-flettefelt-dato)

### Hvordan er det løst? 🧠

Vi har satt ett navn på tidsobjektet for å skape mindre forvirring. Så det heter nå mottatt dato, endret navnet fra innsendt tid til mottatt dato. Denne endringen er det samme som skjer i endringsmelding så denne og endringsmelding repoet er koblet sammen 

<img width="881" alt="Screenshot 2023-07-18 at 09 42 30" src="https://github.com/bekk/nav-familie-endringsmelding-sanity/assets/31205453/4fc12692-2be5-4376-9c4b-d4e58b070009">
