### PR TITLE
Bump sanity og sanity vision til 3.14.2 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@sanity/vision": "^3.11.5",
+        "@sanity/vision": "^3.14.2",
         "groq": "^3.14.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-is": "^18.2.0",
-        "sanity": "^3.11.5",
+        "sanity": "^3.14.2",
         "styled-components": "^5.3.9"
       },
       "devDependencies": {
@@ -2445,24 +2445,24 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.6.tgz",
-      "integrity": "sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g=="
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.9.tgz",
-      "integrity": "sha512-sosQxsqgxMNkV3C+3UqTS6LxP7isRLwX8WMepp843Rb3/b0Wz8+MdUkxJksByip3C2WwLugLHN1b4ibn//zKwQ==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.5.tgz",
+      "integrity": "sha512-96KnRWkRnuBSSFbj0sFGwwOUd8EkiecINVl0O9wiZlZ64EkpyAOG3Xc2vKKNJmru0Z7RqWNymA+6b8OZqjgyyw==",
       "dependencies": {
-        "@floating-ui/core": "^1.2.6"
+        "@floating-ui/core": "^1.3.1"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.1.1.tgz",
-      "integrity": "sha512-F27E+7SLB5NZvwF9Egqx/PlvxOhMnA6k/yNMQUqaQ9BPZdr4fQgSW6J6AKNIrBQElBT8IRDtv9j6h7FDkgp3dA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.0.tgz",
+      "integrity": "sha512-Ke0oU3SeuABC2C4OFu2mSAwHIP5WUiV98O9YWoHV4Q5aT6E9k06DV0Khi5uYspR8xmmBk08t8ZDcz3TR3ARkEg==",
       "dependencies": {
-        "@floating-ui/dom": "^1.1.0"
+        "@floating-ui/dom": "^1.2.7"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2639,45 +2639,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@portabletext/react": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@portabletext/react/-/react-1.0.6.tgz",
-      "integrity": "sha512-j6BprLiwFz3zr1Lo6BxM2sQ1b3g1JIjGwePeuxqSfbBiEYbGXn2izEckMJ02hSa1f7+RCEUJ+Bojvtzz6BBUaw==",
-      "dependencies": {
-        "@portabletext/toolkit": "^1.0.5",
-        "@portabletext/types": "^1.0.3"
-      },
-      "peerDependencies": {
-        "react": "^17 || ^18"
-      }
-    },
-    "node_modules/@portabletext/react/node_modules/@portabletext/types": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@portabletext/types/-/types-1.0.3.tgz",
-      "integrity": "sha512-SDDsdury2SaTI2D5Ea6o+Y39SSZMYHRMWJHxkxYl3yzFP0n/0EknOhoXcoaV+bxGr2dTTqZi2TOEj+uWYuavSw==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/@portabletext/toolkit": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-1.0.8.tgz",
-      "integrity": "sha512-SNO8at5crqySCeYa19/mdcZoZvGCINGc/eAX4FwYt02cEzb48hf013BuA9LbEQuTOgpMKxnyeRGpEzxmowmEug==",
-      "dependencies": {
-        "@portabletext/types": "^2.0.0"
-      },
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/@portabletext/types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@portabletext/types/-/types-2.0.2.tgz",
-      "integrity": "sha512-3xTbSa80G1nODyACY0ilrmPo1PmU1xuoPvfcpzpqSEL0kX01fSW+21PKgS9BcG+GqdG9HK/VxciKWa+nFA7mqg==",
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0 || >=18.0.0"
-      }
-    },
     "node_modules/@rexxars/react-json-inspector": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@rexxars/react-json-inspector/-/react-json-inspector-8.0.1.tgz",
@@ -2729,22 +2690,22 @@
       }
     },
     "node_modules/@sanity/block-tools": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.11.5.tgz",
-      "integrity": "sha512-n7yevgPsCk1H7g01Uy9Pn8iUkSOVg2ZSaCwByv8hO0ph8S7v+4jVlTvrKPS2e5xznqqebX1pI6PWwps6mZiOTQ==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.14.2.tgz",
+      "integrity": "sha512-lbA5yUxbyBV49zBAXccmXx0+69Wy8Ukor3aoD4CSXAHpo0v2zKaWmi50AS9a2m9GQdklyoGVFYBIoF2vNCx6TA==",
       "dependencies": {
         "get-random-values-esm": "^1.0.0",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.11.5.tgz",
-      "integrity": "sha512-f+YSYkH084PKdMYf359VCrQH7/1mTTbsR1veiVr1mUMfE/eblCfyWuHyf35qEGEDn0rlLbfCq+gtSAgV0CK7Ow==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.14.2.tgz",
+      "integrity": "sha512-emWwCn73yFHpY+9Gm+k1ILwZ4Gt6rfhKaUwWZqrCM8+6KrI/dE6UhzCRNppVxTRxrxfjqIEgxP7SQAecsUjCbA==",
       "dependencies": {
         "@babel/traverse": "^7.19.0",
         "@vercel/frameworks": "1.4.2",
-        "@vercel/fs-detectors": "3.9.2",
+        "@vercel/fs-detectors": "3.9.3",
         "chalk": "^4.1.2",
         "esbuild": "^0.16.5",
         "esbuild-register": "^3.4.1",
@@ -2824,9 +2785,9 @@
       }
     },
     "node_modules/@sanity/client": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.1.2.tgz",
-      "integrity": "sha512-8/NRBmyzJaT8ZNZxj3UmOAhvqKxDtXWysogsa4rn+o/Z+zS7upkToh1wSdvoFLcv9uHSYF6JGeycigjwO1Zpnw==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.1.7.tgz",
+      "integrity": "sha512-crleZDBic3VpmBhIuiVZNkJMxAWE/fj5v+hHBXt+2psW1CJrvBdTLX14f4cqC40W1YDDE4ZGrDkYuph6Y6/YzQ==",
       "dependencies": {
         "@sanity/eventsource": "^5.0.0",
         "get-it": "^8.1.0",
@@ -2842,9 +2803,9 @@
       "integrity": "sha512-tTi22KoKuER3sldXYl4c1Dq2zU7tMLDkljFiaUKVkBbu4PBvRGCFw75kXZnD2b4Bsp6vin+7sI+AKdCKRhfRuw=="
     },
     "node_modules/@sanity/diff": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.11.5.tgz",
-      "integrity": "sha512-6iuEJue/Ez6r+SdGXfP8Y8UTSs1UbjRGQ1ShsN01RD+5Wx2Pd4ve/SBb7MijfMquIsBcFyf6R4Zv0MNphe8CUQ==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.14.2.tgz",
+      "integrity": "sha512-NFzWg7TNwcGxN8+qalq7UVmZowYtWjd5jTBYOxIIfQ1zUqnJ4ofR7hBLf2tn/+EPZ4z+i/m+nEQFYJJxU4k3Lg==",
       "dependencies": {
         "diff-match-patch": "^1.0.4"
       },
@@ -2883,9 +2844,9 @@
       }
     },
     "node_modules/@sanity/export": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.11.5.tgz",
-      "integrity": "sha512-lX+sB3vlSorTFeDzAPLhSqI/YCRttZlCRPnzbD+glhpnzbtBC0dtRxbRPU/aprJ+4Nmfdw9B6Q3wR7NDzA5gsw==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.14.2.tgz",
+      "integrity": "sha512-nTGeOry0ZC0OZPBZCT68lzNHyZbRdb1bEnsXfZYd7kBVVALAGseic5O5qeKtkqCN+zBNE8Gp6U7nffkc+i6GqA==",
       "dependencies": {
         "archiver": "^5.0.0",
         "debug": "^3.2.7",
@@ -2914,9 +2875,9 @@
       "integrity": "sha512-wtMYcV5GIDIhVyF/jjmdwq1GdlK07dRL40XMns73VbrFI7FteRltxv48bhYVZPcLkRXb0SHjpDS/icj9/yzbVA=="
     },
     "node_modules/@sanity/icons": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-2.3.1.tgz",
-      "integrity": "sha512-DyUdjjWFIokrMewnK24Vvxpv2lKx5LrzUM3eEk0ZVwhS8+hWkFFN1Z7jhcwQnQ5NweejhzsZkT4JHUdffCAQaw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-2.4.1.tgz",
+      "integrity": "sha512-/yxcIT0k1RxStI/pP/oHM44fHI6Oxiygf0jPcdV06Ce0xfFo+51UEqJSfE8hQ3fh+uFkat8ZZObZjq5v1ceJzw==",
       "engines": {
         "node": ">=14.0.0"
       },
@@ -2933,13 +2894,13 @@
       }
     },
     "node_modules/@sanity/import": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.11.5.tgz",
-      "integrity": "sha512-qDylkoY+Sklmo6fjOqy5DGmuM0vDba1+sZHCzQHdFNoQHgDfBpW6iMNXtL26GZxObu3vKpSTyuTOjTKVZBg1vA==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.14.2.tgz",
+      "integrity": "sha512-CSpECt1pcbH10Wrh31zyzQsV5x26Pk8ws/cQ3ZSI+Xxye51FHOzctIXr+eA9Rlw77Lkz06nMDFCRAyLST7an9Q==",
       "dependencies": {
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/mutator": "3.11.5",
+        "@sanity/mutator": "3.14.2",
         "@sanity/uuid": "^3.0.1",
         "debug": "^3.2.7",
         "file-url": "^2.0.2",
@@ -2999,9 +2960,9 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.11.5.tgz",
-      "integrity": "sha512-DU+hHcwV2FX448mhNWeU3Xaov9TdxaaZoL1Y3aUzECbr7SSmBZqnmKljhdvhHDXEdZcfn7DgGPfQ891P3wASuA==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.14.2.tgz",
+      "integrity": "sha512-Ihs9Y9lCGdvg7e60I6UQV8dHUR8onl6GbF1oOGIDa6YKyFwIzuSZXHAqfEcWEGS6hHUqSgfTYcYH1djrUCpO/g==",
       "dependencies": {
         "@sanity/uuid": "^3.0.1",
         "@types/diff-match-patch": "^1.0.32",
@@ -3019,15 +2980,15 @@
       }
     },
     "node_modules/@sanity/portable-text-editor": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.11.5.tgz",
-      "integrity": "sha512-O/iRZDByVqZZJk0Gma8ofBfChhQd4QN1jNED06RVPzveTbaF9hrBkTWTw30cobs5bloO1bzuQorWIxfYcAwlXw==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.14.2.tgz",
+      "integrity": "sha512-Z0Qqn//os3Yvim+AyWjVxmF5hkR8aEiV7tUB2idRgtYT7Eq5ji9sV6Ae5HhsmlUJ/4ufKNpWAsRUeYixr4Syjg==",
       "dependencies": {
-        "@sanity/block-tools": "3.11.5",
-        "@sanity/schema": "3.11.5",
+        "@sanity/block-tools": "3.14.2",
+        "@sanity/schema": "3.14.2",
         "@sanity/slate-react": "2.30.1",
-        "@sanity/types": "3.11.5",
-        "@sanity/util": "3.11.5",
+        "@sanity/types": "3.14.2",
+        "@sanity/util": "3.14.2",
         "debug": "^3.2.7",
         "is-hotkey": "^0.1.6",
         "lodash": "^4.17.21",
@@ -3051,12 +3012,12 @@
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.11.5.tgz",
-      "integrity": "sha512-vZd9r8PANmyiJaDqynddhEmcVjHtaxkQnAksCGIvDF6o1tDyPQklg8Z+PU9l+uJD6ff6Iwmi+xMUHW3Re0in3A==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.14.2.tgz",
+      "integrity": "sha512-K7zaDyj9V8x0sn+6i6ThlDaLfj2JX6dii/yCQpHguT8lkNNGrIaVxI6/K5pDqQ/QzmBkdEeQ83PPOH5aKrSsbg==",
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.11.5",
+        "@sanity/types": "3.14.2",
         "arrify": "^1.0.1",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
@@ -3098,24 +3059,24 @@
       }
     },
     "node_modules/@sanity/types": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.11.5.tgz",
-      "integrity": "sha512-eFU5BJJ6MGWKfTiNCttUahrrsBbQVsa9kjPJeukjpKqPELLxHroMRScqxpUSIaEdcSOHOyp6DAVLEU8XDFohyw==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.14.2.tgz",
+      "integrity": "sha512-P6Rj8UGaDl7JP7q6iYTxu86mZp/16F9/jQYtG1GQjVKx954FWjvZY2OekiWBsUmNTxhQ2Ql+9fHW07qM6kdIjw==",
       "dependencies": {
-        "@sanity/client": "^6.1.1",
+        "@sanity/client": "^6.1.5",
         "@types/react": "^18.0.25"
       }
     },
     "node_modules/@sanity/ui": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-1.3.3.tgz",
-      "integrity": "sha512-fp5eyc6U760Mvg6wmiv0wOnX/uiPpFoPf4Ne9cJX6X80mk2/u2pOkXCuMuhfXmty3KP7uPZxkapD8atd7BaWIw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-1.7.3.tgz",
+      "integrity": "sha512-C+EBh7Vp0XMKE6k7sAGylc5R9RsZkKu4FnZ2SotVe5CPUTFAqTIqEn2WoaAKVMtkafxplCXd7RQsWr5nJOjqSg==",
       "dependencies": {
-        "@floating-ui/react-dom": "1.1.1",
-        "@sanity/color": "^2.2.3",
-        "@sanity/icons": "^2.2.2",
-        "csstype": "^3.1.1",
-        "framer-motion": "^10.0.0",
+        "@floating-ui/react-dom": "2.0.0",
+        "@sanity/color": "^2.2.5",
+        "@sanity/icons": "^2.3.1",
+        "csstype": "^3.1.2",
+        "framer-motion": "^10.12.16",
         "react-refractor": "^2.1.7"
       },
       "engines": {
@@ -3129,11 +3090,11 @@
       }
     },
     "node_modules/@sanity/util": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.11.5.tgz",
-      "integrity": "sha512-rLcBq9sOKlMT+zmqSAx/5Ti8kT02kuB9p8z2/cYYBHF9O67aU4JUfzg8rlmWFwyQl9R+w0ZRQsJGQyyrul5z0w==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.14.2.tgz",
+      "integrity": "sha512-iMW/nvs8RnYiLrVekVZ1jI5e0CC9V8CnDB4j6fMbqu4DQpur1KIErZJ/JRF3mVXalUbqAZGWGAwluqomKT3ZwA==",
       "dependencies": {
-        "@sanity/types": "3.11.5",
+        "@sanity/types": "3.14.2",
         "get-random-values-esm": "^1.0.0",
         "moment": "^2.29.4"
       },
@@ -3142,29 +3103,29 @@
       }
     },
     "node_modules/@sanity/uuid": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sanity/uuid/-/uuid-3.0.1.tgz",
-      "integrity": "sha512-cfWq8l/M6TiDYlp2VYJR2MNdrl0u/lkYWjJVflLHsiGjG8SZKbbRSsfG1fn7rSvdZg+o/xfBlKCfhFTtEiXKJg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@sanity/uuid/-/uuid-3.0.2.tgz",
+      "integrity": "sha512-vzdhqOrX7JGbMyK40KuIwwyXHm7GMLOGuYgn3xlC09e4ZVNofUO5mgezQqnRv0JAMthIRhofqs9f6ufUjMKOvw==",
       "dependencies": {
         "@types/uuid": "^8.0.0",
         "uuid": "^8.0.0"
       }
     },
     "node_modules/@sanity/validation": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/@sanity/validation/-/validation-3.11.5.tgz",
-      "integrity": "sha512-b+R4g6xZWIp/ebdsXl0Kjm/JZb5DCeRmTtO4S/Ywu47BP10mENRYqaJ4AlXOo4sba75rp8+V7c2SHI7gaBlXMA==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@sanity/validation/-/validation-3.14.2.tgz",
+      "integrity": "sha512-4ML1OjokFC8PNqPtzxWTve40WcQUBn7ik3qDsbuAiPDDXYAgfzhUf6U4kMI9oXU0U54CC1ifIaYM5X59NyRznA==",
       "dependencies": {
-        "@sanity/types": "3.11.5",
+        "@sanity/types": "3.14.2",
         "date-fns": "^2.26.1",
         "lodash": "^4.17.21",
         "rxjs": "^7.8.0"
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.11.5.tgz",
-      "integrity": "sha512-loZY3XGmj+U6pYGdEOfWsGQWNF1B8/RskwsCtjHEE4ji1PCsmZxcYr+VaVZhp2khl2wkJRWdVA8mFdTQieWXwA==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.14.2.tgz",
+      "integrity": "sha512-N6iJO6vSCnXqIFJ9Ui77DZRRQ/UznAOMozLjdSGxj1aHxKP39HJwuNsEy2eUrMnTiloqQ2MEBfs+zrbVRL9r+w==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.1.0",
         "@codemirror/commands": "^6.0.1",
@@ -3177,8 +3138,8 @@
         "@rexxars/react-json-inspector": "^8.0.1",
         "@rexxars/react-split-pane": "^0.1.93",
         "@sanity/color": "^2.1.20",
-        "@sanity/icons": "^2.3.0",
-        "@sanity/ui": "^1.3.3",
+        "@sanity/icons": "^2.4.0",
+        "@sanity/ui": "^1.6.0",
         "@uiw/react-codemirror": "^4.11.4",
         "hashlru": "^2.3.0",
         "is-hotkey": "^0.1.6",
@@ -3247,11 +3208,11 @@
       }
     },
     "node_modules/@types/hast": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
-      "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.5.tgz",
+      "integrity": "sha512-SvQi0L/lNpThgPoleH53cdjB3y9zpLlVjRbqB3rH8hx1jiRSBGAhyjV3H+URFjNVRqt2EdYNrbZE5IsGlNfpRg==",
       "dependencies": {
-        "@types/unist": "*"
+        "@types/unist": "^2"
       }
     },
     "node_modules/@types/hoist-non-react-statics": {
@@ -3319,21 +3280,11 @@
       }
     },
     "node_modules/@types/react-is": {
-      "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.4.tgz",
-      "integrity": "sha512-FLzd0K9pnaEvKz4D1vYxK9JmgQPiGk1lu23o1kqGsLeT0iPbRSF7b76+S5T9fD8aRa0B8bY7I/3DebEj+1ysBA==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.1.tgz",
+      "integrity": "sha512-wyUkmaaSZEzFZivD8F2ftSyAfk6L+DfFliVj/mYdOXbVjRcS87fQJLTnhk6dRZPuJjI+9g6RZJO4PNCngUrmyw==",
       "dependencies": {
-        "@types/react": "^17"
-      }
-    },
-    "node_modules/@types/react-is/node_modules/@types/react": {
-      "version": "17.0.60",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.60.tgz",
-      "integrity": "sha512-pCH7bqWIfzHs3D+PDs3O/COCQJka+Kcw3RnO9rFA2zalqoXg7cNjJDh6mZ7oRtY1wmY4LVwDdAbA1F7Z8tv3BQ==",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
+        "@types/react": "*"
       }
     },
     "node_modules/@types/scheduler": {
@@ -3369,9 +3320,9 @@
       }
     },
     "node_modules/@types/unist": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.7.tgz",
+      "integrity": "sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g=="
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
@@ -3762,9 +3713,9 @@
       }
     },
     "node_modules/@vercel/fs-detectors": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@vercel/fs-detectors/-/fs-detectors-3.9.2.tgz",
-      "integrity": "sha512-fApNP4um51mB2DRe4DKmLlPpFiNrlShBNZdxf4sNx0hmempQ3g7BBirqKD66VWEFHRTmO3gctzuhNpBXVTD/+w==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@vercel/fs-detectors/-/fs-detectors-3.9.3.tgz",
+      "integrity": "sha512-R6hM4Thh2dZI1oWjxTLuvLpvjUIBPTveHHUVNlcAn9JqOUXL4BYPIit6r376e/ufXnA47oNPN7C1gf4Mk5hfzA==",
       "dependencies": {
         "@vercel/error-utils": "1.0.10",
         "@vercel/frameworks": "1.4.2",
@@ -6076,9 +6027,9 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "10.12.16",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.16.tgz",
-      "integrity": "sha512-w/SfWEIWJkYSgRHYBmln7EhcNo31ao8Xexol8lGXf1pR/tlnBtf1HcxoUmEiEh6pacB4/geku5ami53AAQWHMQ==",
+      "version": "10.12.22",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.22.tgz",
+      "integrity": "sha512-bBGYPOxvxcfzS7/py9MEqDucmXBkVl2g42HNlXXPieSTSGGkr8L7+MilCnrU6uX3HrNk/tcB++1SkWE8BosHFw==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -6259,9 +6210,9 @@
       }
     },
     "node_modules/get-it": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.1.3.tgz",
-      "integrity": "sha512-cbyYSla0qAQrwirBNHM4CERo8H32eUWNxhsby4AcKiRW3jIwMPDhgLnR0Ok/UmZO68vsccjRCFbZFEeB3BXvLg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.3.0.tgz",
+      "integrity": "sha512-R8rM45CWEI1shdTegGCs/9yy/z6DgwS5XMVIVZtSVpu0XABxPp3PA3TCl6mzVQOcHecbqD+VUFg1poAtBtO19A==",
       "dependencies": {
         "debug": "^4.3.4",
         "decompress-response": "^7.0.0",
@@ -9552,44 +9503,42 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sanity": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.11.5.tgz",
-      "integrity": "sha512-K8u8mVODon7CWc/GUoPSnQ8H99zBnn4XIs9VaMeDyc9VU0MKlhHvo7ItNTVLEPEZoF/7X5oY3pQqPcZLLQbVsg==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.14.2.tgz",
+      "integrity": "sha512-YD/Lb5j5+LoqBjwQyBeV1ZeF17vs2YLBHn1TLLoKo+KGoyEJ+t82914+VlsXcgoRAZcqBPAL54S2qsfKCKhFcg==",
       "dependencies": {
         "@dnd-kit/core": "^6.0.5",
         "@dnd-kit/modifiers": "^6.0.0",
         "@dnd-kit/sortable": "^7.0.1",
         "@dnd-kit/utilities": "^3.2.0",
         "@juggle/resize-observer": "^3.3.1",
-        "@portabletext/react": "^1.0.6",
-        "@portabletext/types": "^2.0.0",
         "@rexxars/react-json-inspector": "^8.0.1",
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/bifur-client": "^0.3.1",
-        "@sanity/block-tools": "3.11.5",
-        "@sanity/cli": "3.11.5",
-        "@sanity/client": "^6.1.1",
+        "@sanity/block-tools": "3.14.2",
+        "@sanity/cli": "3.14.2",
+        "@sanity/client": "^6.1.5",
         "@sanity/color": "^2.1.20",
-        "@sanity/diff": "3.11.5",
+        "@sanity/diff": "3.14.2",
         "@sanity/eventsource": "^5.0.0",
-        "@sanity/export": "3.11.5",
+        "@sanity/export": "3.14.2",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/icons": "^2.3.0",
+        "@sanity/icons": "^2.4.0",
         "@sanity/image-url": "^1.0.2",
-        "@sanity/import": "3.11.5",
+        "@sanity/import": "3.14.2",
         "@sanity/logos": "^2.0.2",
-        "@sanity/mutator": "3.11.5",
-        "@sanity/portable-text-editor": "3.11.5",
-        "@sanity/schema": "3.11.5",
-        "@sanity/types": "3.11.5",
-        "@sanity/ui": "^1.3.3",
-        "@sanity/util": "3.11.5",
+        "@sanity/mutator": "3.14.2",
+        "@sanity/portable-text-editor": "3.14.2",
+        "@sanity/schema": "3.14.2",
+        "@sanity/types": "3.14.2",
+        "@sanity/ui": "^1.6.0",
+        "@sanity/util": "3.14.2",
         "@sanity/uuid": "^3.0.1",
-        "@sanity/validation": "3.11.5",
+        "@sanity/validation": "3.14.2",
         "@tanstack/react-virtual": "3.0.0-beta.54",
         "@types/is-hotkey": "^0.1.7",
         "@types/react-copy-to-clipboard": "^5.0.2",
-        "@types/react-is": "^17.0.3",
+        "@types/react-is": "^18.2.0",
         "@types/shallow-equals": "^1.0.0",
         "@types/speakingurl": "^13.0.3",
         "@types/use-sync-external-store": "^0.0.3",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "sanity"
   ],
   "dependencies": {
-    "@sanity/vision": "^3.11.5",
+    "@sanity/vision": "^3.14.2",
     "groq": "^3.14.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-is": "^18.2.0",
-    "sanity": "^3.11.5",
+    "sanity": "^3.14.2",
     "styled-components": "^5.3.9"
   },
   "devDependencies": {


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
Pakke bump fra sanity! Sanity pakker går opp til versjon `3.14.2`.
Pakkene som skal bumpes er: 

- sanity
- @sanity/vision

Dependabot PR som gjør det samme: #44 og #45 

### Hvordan er det løst? 🧠

Bumper pakker manuelt. Hvorfor? 
Pakkene er avhengige (muligens). Bestemte derfor å gjør det manuelt. 
Ingen endringer for det funksjonelle. Se test av både sanity studio og spørring;

<img width="1270" alt="Screenshot 2023-07-18 at 15 55 36" src="https://github.com/bekk/nav-familie-endringsmelding-sanity/assets/66110094/a01ceba2-0532-4302-90a8-8d401070dcea">


![image](https://github.com/bekk/nav-familie-endringsmelding-sanity/assets/66110094/df268795-a2db-4b2f-b498-d41d52cc4956)

