### PR TITLE
Legger til dokumentasjon mappe i sanity

### DIFF
--- a/schemas/typer.ts
+++ b/schemas/typer.ts
@@ -73,6 +73,7 @@ export enum Steg {
   SEND_ENDRINGER = 'SEND_ENDRINGER',
   KVITTERING = 'KVITTERING',
   FELLES = 'FELLES',
+  DOKUMENTASJON = 'DOKUMENTASJON',
 }
 
 export const stegTittel: Record<Steg, string> = {
@@ -80,6 +81,7 @@ export const stegTittel: Record<Steg, string> = {
   SEND_ENDRINGER: 'Send endringer',
   KVITTERING: 'Kvittering',
   FELLES: 'Felles',
+  DOKUMENTASJON: 'dokumentasjon',
 }
 
 export enum EFlettefelt {

--- a/schemas/typer.ts
+++ b/schemas/typer.ts
@@ -81,7 +81,7 @@ export const stegTittel: Record<Steg, string> = {
   SEND_ENDRINGER: 'Send endringer',
   KVITTERING: 'Kvittering',
   FELLES: 'Felles',
-  DOKUMENTASJON: 'dokumentasjon',
+  DOKUMENTASJON: 'Dokumentasjon',
 }
 
 export enum EFlettefelt {

--- a/schemas/ytelse/barnetrygd.ts
+++ b/schemas/ytelse/barnetrygd.ts
@@ -8,5 +8,6 @@ export const barnetrygd = () => {
     barnetrygdLocaleDokument(Steg.SEND_ENDRINGER),
     barnetrygdLocaleDokument(Steg.KVITTERING),
     barnetrygdLocaleDokument(Steg.FELLES),
+    barnetrygdLocaleDokument(Steg.DOKUMENTASJON),
   ]
 }

--- a/schemas/ytelse/kontantstøtte.ts
+++ b/schemas/ytelse/kontantstøtte.ts
@@ -8,5 +8,6 @@ export const kontantstøtte = () => {
     kontantstøtteLocaleDokument(Steg.SEND_ENDRINGER),
     kontantstøtteLocaleDokument(Steg.KVITTERING),
     kontantstøtteLocaleDokument(Steg.FELLES),
+    kontantstøtteLocaleDokument(Steg.DOKUMENTASJON),
   ]
 }

--- a/structure.ts
+++ b/structure.ts
@@ -19,6 +19,7 @@ export const structure = (S: StructureBuilder, _context: StructureContext) => {
         lagStegmappe(Ytelse.BARNETRYGD, Steg.SEND_ENDRINGER),
         lagStegmappe(Ytelse.BARNETRYGD, Steg.KVITTERING),
         lagStegmappe(Ytelse.BARNETRYGD, Steg.FELLES),
+        lagStegmappe(Ytelse.BARNETRYGD, Steg.DOKUMENTASJON),
       ]),
       lagYtelsemappe(Ytelse.KONTANTSTOTTE, [
         lagStegmappe(Ytelse.KONTANTSTOTTE, Steg.FORSIDE),

--- a/structure.ts
+++ b/structure.ts
@@ -26,6 +26,7 @@ export const structure = (S: StructureBuilder, _context: StructureContext) => {
         lagStegmappe(Ytelse.KONTANTSTOTTE, Steg.SEND_ENDRINGER),
         lagStegmappe(Ytelse.KONTANTSTOTTE, Steg.KVITTERING),
         lagStegmappe(Ytelse.KONTANTSTOTTE, Steg.FELLES),
+        lagStegmappe(Ytelse.KONTANTSTOTTE, Steg.DOKUMENTASJON),
       ]),
     ])
 }


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
Tekstene på dokumentasjonsiden skal hentes fra sanity og derfor trenger vi en mappe der vi kan ha alt vi trenger for dokumentasjon 
[Lenke til trello kort](https://trello.com/c/jdVXobuF/154-legge-til-dokumentasjon-i-sanity-som-et-steg)

### Hvordan er det løst? 🧠
la til dokumentasjon i de filene som trengte det for at mappen skulle vises i sanity  